### PR TITLE
Make window resizing set `recreate_swapchain`

### DIFF
--- a/deferred/main.rs
+++ b/deferred/main.rs
@@ -172,6 +172,7 @@ fn main() {
         events_loop.poll_events(|ev| {
             match ev {
                 winit::Event::WindowEvent { event: winit::WindowEvent::Closed, .. } => done = true,
+                winit::Event::WindowEvent { event: winit::WindowEvent::Resized(_, _), .. } => recreate_swapchain = true,
                 _ => ()
             }
         });

--- a/triangle/main.rs
+++ b/triangle/main.rs
@@ -465,6 +465,7 @@ void main() {
         events_loop.poll_events(|ev| {
             match ev {
                 winit::Event::WindowEvent { event: winit::WindowEvent::Closed, .. } => done = true,
+                winit::Event::WindowEvent { event: winit::WindowEvent::Resized(_, _), .. } => recreate_swapchain = true,
                 _ => ()
             }
         });


### PR DESCRIPTION
On my machine at least, resizing the window wasn't resulting in the window being cleared or drawn to correctly:

https://i.imgur.com/0I2eLPI.png

Explicitly listening to `Resized` and setting the `recreate_swapchain` flag in the examples fixes the issue. I'm not sure if it's completely correct, but it's an improvement in behavior.