### PR TITLE
Fix using inline render pass instead of secondary

### DIFF
--- a/deferred/frame/system.rs
+++ b/deferred/frame/system.rs
@@ -335,7 +335,7 @@ impl<'a> Frame<'a> {
                     self.command_buffer
                         .take()
                         .unwrap()
-                        .next_subpass(false)
+                        .next_subpass(true)
                         .unwrap()
                 );
 


### PR DESCRIPTION
Vulkano doesn't check this yet.