### PR TITLE
msaa-renderpass: Fixed inconsitent clear values to begin_render_pass

### DIFF
--- a/msaa-renderpass/main.rs
+++ b/msaa-renderpass/main.rs
@@ -233,7 +233,7 @@ fn main() {
                                              .expect("failed to create buffer");
 
     let command_buffer = AutoCommandBufferBuilder::primary_one_time_submit(device.clone(), queue.family()).unwrap()
-        .begin_render_pass(framebuffer.clone(), false, vec![[0.0, 0.0, 1.0, 1.0].into()])
+        .begin_render_pass(framebuffer.clone(), false, vec![[0.0, 0.0, 1.0, 1.0].into(), vulkano::format::ClearValue::None])
         .unwrap()
 
         .draw(pipeline.clone(), dynamic_state, vertex_buffer.clone(), (), ())


### PR DESCRIPTION
The begin_render_pass documentation says (https://docs.rs/vulkano/0.9.0/vulkano/command_buffer/struct.AutoCommandBufferBuilder.html#method.begin_render_pass)

> C must contain exactly one clear value for each attachment in the
> framebuffer.


This commit adds an extra ClearValue::None for the second render pass
attachment.